### PR TITLE
fix: add `:only-of-type::before` pseudo-selector 

### DIFF
--- a/components/time-counter.vue
+++ b/components/time-counter.vue
@@ -63,6 +63,10 @@ useIntervalFn(
 	content: 'and ';
 }
 
+.counter > :only-of-type::before {
+	content: '';
+}
+
 .counter.positive::before {
 	content: 'In '
 }


### PR DESCRIPTION
Dates with seconds only incorrectly display **"and"** prepended to the number. 
Added selector to remove the word so they display correctly.

### Examples:

#### Before:

![image](https://github.com/user-attachments/assets/6ca84cb8-ff16-483b-a190-fcf5fa05c42e)

![image](https://github.com/user-attachments/assets/5217d28e-3d0f-4ace-b600-3095a2b130df)


#### After:

![image](https://github.com/user-attachments/assets/e32b3c0a-5d42-4027-a4f5-186271c7b2fc)

![image](https://github.com/user-attachments/assets/7c647d19-33fd-4875-8111-c89a8caf1646)
